### PR TITLE
Add trackInlineScripts to BrowserConfig

### DIFF
--- a/packages/browser/types/bugsnag.d.ts
+++ b/packages/browser/types/bugsnag.d.ts
@@ -4,6 +4,7 @@ interface BrowserConfig extends Config {
   maxEvents?: number
   collectUserIp?: boolean
   generateAnonymousId?: boolean
+  trackInlineScripts?: boolean
 }
 
 interface BrowserBugsnagStatic extends BugsnagStatic {


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->

`trackInlineScripts` is supported on the browser and should be reflected in the TypeScript types ([docs](https://docs.bugsnag.com/platforms/javascript/configuration-options/#trackinlinescripts-browser-only)), but is not represented in the .d.ts file.

## Design

<!-- Why was this approach used? -->

This pattern matches all the other "browser only" configuration options.

## Changeset

<!-- What changed? -->

Added `trackInlineScripts` to `BrowserConfig`.

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->

N/A, just a TypeScript definiton.